### PR TITLE
Update Firefox manifest.json to allow loading as temporary add-on

### DIFF
--- a/firefox/privacy-please-firefox/manifest.json
+++ b/firefox/privacy-please-firefox/manifest.json
@@ -22,7 +22,7 @@
     "*://*.quora.com/*"
   ],
   "background": {
-    "service_worker": "js/background.js"
+    "scripts": ["js/background.js"]
   },
   "action": {
     "default_popup": "html/popup.html",


### PR DESCRIPTION
When attempting to add the Firefox extension as a temporary add-on for testing, it throws this error.  (You need to add it, then either refresh the page or go to Setup on the left and back to This Firefox to see it). 

```
There was an error during the temporary add-on installation. Error details: 
background.service_worker is currently disabled. Add background.scripts.
```

It looks like it's due to the V2/V3 support differences between Firefox and Chrome, I [found this](https://stackoverflow.com/a/75203925) which has the fix, I just don't know enough about the manifests to know if this was intentional and there's a build tool that works around it or something. 

I can confirm that with this change it'll allow loading it as a temporary add-on for testing though.