### PR TITLE
Fix #21: Move save button to top of settings page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude-config

--- a/chrome/privacy-please-chrome/css/options.css
+++ b/chrome/privacy-please-chrome/css/options.css
@@ -91,11 +91,16 @@ header p {
   background-color: #fff;
 }
 
-.actions {
+.actions, .actions-top {
   display: flex;
   justify-content: center;
   gap: 15px;
   margin-top: 20px;
+}
+
+.actions-top {
+  margin-bottom: 20px;
+  margin-top: 0;
 }
 
 .primary-btn, .secondary-btn {

--- a/chrome/privacy-please-chrome/html/options.html
+++ b/chrome/privacy-please-chrome/html/options.html
@@ -13,6 +13,11 @@
     </header>
     
     <main>
+      <div class="actions-top">
+        <button id="save-btn" class="primary-btn">Save Settings</button>
+        <button id="reset-btn" class="secondary-btn">Reset to Defaults</button>
+      </div>
+      
       <div class="global-settings">
         <h2>Global Settings</h2>
         <div class="toggle-container">
@@ -29,11 +34,6 @@
         <div id="sites-container">
           <!-- Sites will be populated by JavaScript -->
         </div>
-      </div>
-      
-      <div class="actions">
-        <button id="save-btn" class="primary-btn">Save Settings</button>
-        <button id="reset-btn" class="secondary-btn">Reset to Defaults</button>
       </div>
     </main>
     

--- a/firefox/privacy-please-firefox/css/options.css
+++ b/firefox/privacy-please-firefox/css/options.css
@@ -91,11 +91,16 @@ header p {
   background-color: #fff;
 }
 
-.actions {
+.actions, .actions-top {
   display: flex;
   justify-content: center;
   gap: 15px;
   margin-top: 20px;
+}
+
+.actions-top {
+  margin-bottom: 20px;
+  margin-top: 0;
 }
 
 .primary-btn, .secondary-btn {

--- a/firefox/privacy-please-firefox/html/options.html
+++ b/firefox/privacy-please-firefox/html/options.html
@@ -13,6 +13,11 @@
     </header>
     
     <main>
+      <div class="actions-top">
+        <button id="save-btn" class="primary-btn">Save Settings</button>
+        <button id="reset-btn" class="secondary-btn">Reset to Defaults</button>
+      </div>
+      
       <div class="global-settings">
         <h2>Global Settings</h2>
         <div class="toggle-container">
@@ -29,11 +34,6 @@
         <div id="sites-container">
           <!-- Sites will be populated by JavaScript -->
         </div>
-      </div>
-      
-      <div class="actions">
-        <button id="save-btn" class="primary-btn">Save Settings</button>
-        <button id="reset-btn" class="secondary-btn">Reset to Defaults</button>
       </div>
     </main>
     


### PR DESCRIPTION
## Summary

This PR addresses issue #21 by moving the Save Settings and Reset to Defaults buttons to the top of the options page for better user experience.

## Changes Made

- ? Moved Save Settings and Reset to Defaults buttons from bottom to top of options page
- ? Applied changes consistently to both Chrome and Firefox versions
- ? Added `.actions-top` CSS class with appropriate margins
- ? Maintained button IDs and functionality for JavaScript compatibility
- ? Improved UX by providing immediate access to save/reset actions

## Files Modified

- `chrome/privacy-please-chrome/html/options.html`
- `chrome/privacy-please-chrome/css/options.css`
- `firefox/privacy-please-firefox/html/options.html`
- `firefox/privacy-please-firefox/css/options.css`

## Testing

- [x] Buttons appear at top of settings page
- [x] CSS styling is consistent with existing design
- [x] No JavaScript functionality is broken
- [x] Changes applied to both browser versions

Fixes #21