### PR TITLE
Fix #1: Add GitHub links to addon pages

### DIFF
--- a/chrome/privacy-please-chrome/css/options.css
+++ b/chrome/privacy-please-chrome/css/options.css
@@ -132,6 +132,15 @@ footer {
   font-size: 12px;
 }
 
+footer a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+footer a:hover {
+  text-decoration: underline;
+}
+
 /* Switch styling */
 .switch {
   position: relative;

--- a/chrome/privacy-please-chrome/css/popup.css
+++ b/chrome/privacy-please-chrome/css/popup.css
@@ -92,7 +92,9 @@ h2 {
 
 .footer {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
 }
 
 #options-btn {
@@ -108,6 +110,17 @@ h2 {
 
 #options-btn:hover {
   background-color: #2980b9;
+}
+
+.github-link a {
+  color: #7f8c8d;
+  text-decoration: none;
+  font-size: 12px;
+}
+
+.github-link a:hover {
+  color: #2c3e50;
+  text-decoration: underline;
 }
 
 /* Switch styling */

--- a/chrome/privacy-please-chrome/html/options.html
+++ b/chrome/privacy-please-chrome/html/options.html
@@ -39,6 +39,7 @@
     
     <footer>
       <p>Privacy Please Extension v1.0.0</p>
+      <p><a href="https://github.com/DoingFedTime/PrivacyPlease" target="_blank" rel="noopener noreferrer">🔗 View on GitHub</a></p>
     </footer>
   </div>
   

--- a/chrome/privacy-please-chrome/html/popup.html
+++ b/chrome/privacy-please-chrome/html/popup.html
@@ -30,6 +30,9 @@
     
     <div class="footer">
       <button id="options-btn">Options</button>
+      <div class="github-link">
+        <a href="https://github.com/DoingFedTime/PrivacyPlease" target="_blank" rel="noopener noreferrer">🔗 GitHub</a>
+      </div>
     </div>
   </div>
   

--- a/firefox/privacy-please-firefox/css/options.css
+++ b/firefox/privacy-please-firefox/css/options.css
@@ -132,6 +132,15 @@ footer {
   font-size: 12px;
 }
 
+footer a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+footer a:hover {
+  text-decoration: underline;
+}
+
 /* Switch styling */
 .switch {
   position: relative;

--- a/firefox/privacy-please-firefox/css/popup.css
+++ b/firefox/privacy-please-firefox/css/popup.css
@@ -92,7 +92,9 @@ h2 {
 
 .footer {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
 }
 
 #options-btn {
@@ -108,6 +110,17 @@ h2 {
 
 #options-btn:hover {
   background-color: #2980b9;
+}
+
+.github-link a {
+  color: #7f8c8d;
+  text-decoration: none;
+  font-size: 12px;
+}
+
+.github-link a:hover {
+  color: #2c3e50;
+  text-decoration: underline;
 }
 
 /* Switch styling */

--- a/firefox/privacy-please-firefox/html/options.html
+++ b/firefox/privacy-please-firefox/html/options.html
@@ -39,6 +39,7 @@
     
     <footer>
       <p>Privacy Please Extension v1.0.0</p>
+      <p><a href="https://github.com/DoingFedTime/PrivacyPlease" target="_blank" rel="noopener noreferrer">🔗 View on GitHub</a></p>
     </footer>
   </div>
   

--- a/firefox/privacy-please-firefox/html/popup.html
+++ b/firefox/privacy-please-firefox/html/popup.html
@@ -30,6 +30,9 @@
     
     <div class="footer">
       <button id="options-btn">Options</button>
+      <div class="github-link">
+        <a href="https://github.com/DoingFedTime/PrivacyPlease" target="_blank" rel="noopener noreferrer">🔗 GitHub</a>
+      </div>
     </div>
   </div>
   


### PR DESCRIPTION
## Summary

This PR addresses issue #1 by adding GitHub repository links to both the popup and options pages of the extension.

## Changes Made

- ✅ Added GitHub repository link to popup page (below options button)
- ✅ Added GitHub repository link to options page (in footer)
- ✅ Applied changes consistently to both Chrome and Firefox versions
- ✅ Added appropriate CSS styling for link hover states
- ✅ Used security best practices (target='_blank' with rel='noopener noreferrer')
- ✅ Maintained consistent design language with existing UI

## Files Modified

- Chrome popup: `html/popup.html` & `css/popup.css`
- Chrome options: `html/options.html` & `css/options.css`
- Firefox popup: `html/popup.html` & `css/popup.css`
- Firefox options: `html/options.html` & `css/options.css`

## Design Decisions

- **Popup**: Link placed below options button for easy discovery
- **Options**: Link placed in footer for non-intrusive access
- **Styling**: Subtle gray color that brightens on hover
- **Security**: Links open in new tab with proper security attributes

Fixes #1