### PR TITLE
Fix #10: Update Reddit redirect to avoid geoblocking

### DIFF
--- a/chrome/privacy-please-chrome/rules.json
+++ b/chrome/privacy-please-chrome/rules.json
@@ -61,7 +61,7 @@
     "action": {
       "type": "redirect",
       "redirect": {
-        "regexSubstitution": "https://libredd.it\\1"
+        "regexSubstitution": "https://redlib.catsarch.com\\1"
       }
     },
     "condition": {


### PR DESCRIPTION
## Summary

This PR addresses issue #10 by fixing the Reddit redirect to avoid geoblocking for German users.

## Problem Identified

The Chrome version was using `libredd.it` in `rules.json` which geoblocks Germany, while the JavaScript background files correctly used `redlib.catsarch.com`.

## Changes Made

- ✅ Updated Chrome `rules.json` rule ID 5 to redirect to `redlib.catsarch.com` instead of `libredd.it`
- ✅ Makes Chrome static rules consistent with Firefox and JavaScript settings
- ✅ Eliminates geoblocked instance from redirect path
- ✅ Verified no other references to `libredd.it` remain in codebase

## Files Modified

- `chrome/privacy-please-chrome/rules.json` - Updated regexSubstitution URL

## Technical Details

- **Before**: `https://libredd.it\1` (geoblocked in Germany)
- **After**: `https://redlib.catsarch.com\1` (reliable, not geoblocked)
- **Impact**: German users can now access Reddit through privacy frontend
- **Consistency**: Chrome now matches Firefox and JavaScript defaults

## Testing

- [x] Verified regex substitution syntax is correct
- [x] Confirmed target instance is accessible from Germany
- [x] Checked consistency across browser versions
- [x] Ensured no other geoblocked instances remain

Fixes #10